### PR TITLE
Fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": "https://github.com/sunesimonsen/eslint-config-pretty-standard/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sunesimonsen/eslint-config-pretty-standard"
+    "url": "https://github.com/sunesimonsen/eslint-config-pretty-standard.git"
   }
   "peerDependencies": {
     "eslint": "^3.17.1"


### PR DESCRIPTION
`npm` requires the repository url to include the `.git` so it's linked from the https://www.npmjs.com/package/eslint-config-pretty-standard

See https://docs.npmjs.com/files/package.json#repository

 