### PR TITLE
Update the eslint plugins so they're all compatible with eslint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
   },
   "peerDependencies": {
     "eslint": "^3.17.1 || 4",
-    "eslint-plugin-flowtype": "2.30.3",
-    "eslint-plugin-promise": "3.5.0",
-    "eslint-plugin-react": "6.10.0",
-    "eslint-plugin-standard": "2.1.1"
+    "eslint-plugin-flowtype": "^2.42.0",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-react": "^7.6.1",
+    "eslint-plugin-standard": "^3.0.1"
   },
   "dependencies": {
-    "eslint-plugin-flowtype": "2.30.3",
-    "eslint-plugin-promise": "3.5.0",
-    "eslint-plugin-react": "6.10.0",
-    "eslint-plugin-standard": "2.1.1"
+    "eslint-plugin-flowtype": "2.42.0",
+    "eslint-plugin-promise": "3.6.0",
+    "eslint-plugin-react": "7.6.1",
+    "eslint-plugin-standard": "3.0.1"
   },
   "devDependencies": {
     "eslint": "^3.17.1"


### PR DESCRIPTION
Also, use liberal version ranges for the peer deps.

Prerequisite for https://github.com/unexpectedjs/unexpected/pull/436