### PR TITLE
Swap mocha globals with mocha env

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,7 +87,8 @@
   },
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "rules": {
     "accessor-pairs": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,11 +79,7 @@
     "setTimeout": false,
     "document": false,
     "navigator": false,
-    "window": false,
-    "describe": false,
-    "it": false,
-    "beforeEach": false,
-    "afterEach": false
+    "window": false
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
The globals meant for mocha weren't covering all the globals and since eslint supports a `mocha` env, this PR uses that instead.

I've checked and eslint v3.17.1 (the lower peerDep) does have support for the `mocha` env: https://github.com/eslint/eslint/blob/v3.17.1/docs/user-guide/configuring.md#specifying-environments