### PR TITLE
Add ignoreRestSiblings true to no-unused-vars rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -203,7 +203,8 @@
       "error",
       {
         "vars": "all",
-        "args": "none"
+        "args": "none",
+        "ignoreRestSiblings": true
       }
     ],
     "no-use-before-define": [


### PR DESCRIPTION
This updates the `ignoreRestSiblings` value to `true` for `no-unused-vars` rule according to the standard: https://github.com/standard/eslint-config-standard/blob/master/eslintrc.json#L151.