### PR TITLE
Remove unused peer dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -268,5 +268,5 @@
     },
     "sourceType": "module"
   },
-  "plugins": ["promise", "react", "flowtype"]
+  "plugins": ["promise", "react"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -268,5 +268,5 @@
     },
     "sourceType": "module"
   },
-  "plugins": ["standard", "promise", "react", "flowtype"]
+  "plugins": ["promise", "react", "flowtype"]
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,10 @@
   },
   "peerDependencies": {
     "eslint": "^3.17.1 || 4",
-    "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.6.1"
   },
   "dependencies": {
-    "eslint-plugin-flowtype": "2.42.0",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-react": "7.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -19,14 +19,12 @@
     "eslint": "^3.17.1 || 4",
     "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.6.1",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-react": "^7.6.1"
   },
   "dependencies": {
     "eslint-plugin-flowtype": "2.42.0",
     "eslint-plugin-promise": "3.6.0",
-    "eslint-plugin-react": "7.6.1",
-    "eslint-plugin-standard": "3.0.1"
+    "eslint-plugin-react": "7.6.1"
   },
   "devDependencies": {
     "eslint": "^3.17.1"


### PR DESCRIPTION
This config references 4 plugins: react, promise, flowtype and standard. But only rules from the first two are actually referenced in the rules section of the configuration.