### PR TITLE
Update eslint to 5 (Major)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -260,10 +260,9 @@
     "react/react-in-jsx-scope": "error"
   },
   "parserOptions": {
-    "ecmaVersion": 8,
+    "ecmaVersion": 9,
     "ecmaFeatures": {
       "globalReturn": true,
-      "experimentalObjectRestSpread": true,
       "jsx": true
     },
     "sourceType": "module"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/sunesimonsen/eslint-config-pretty-standard.git"
   },
   "peerDependencies": {
-    "eslint": "^3.17.1 || 4",
+    "eslint": "^5",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "eslint-plugin-react": "7.6.1"
   },
   "devDependencies": {
-    "eslint": "^3.17.1"
+    "eslint": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "eslint-plugin-promise": "3.6.0",
-    "eslint-plugin-react": "7.6.1"
+    "eslint-plugin-react": "7.10.0"
   },
   "devDependencies": {
     "eslint": "^5.0.0"


### PR DESCRIPTION
It currently works, except for the unmet peer dep (which makes `npm install` fail with npm 2.x/node.js 4), and this warning:

```
(node:29919) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "pretty-standard")
```

I suggest dropping support for earlier eslint versions so that we can avoid conditionally applying this patch:

https://github.com/standard/eslint-config-standard/commit/6a89a51a2a0993e3e6f37f72eb4a461f754a593b

TODO:

- [ ] Await https://github.com/yannickcr/eslint-plugin-react/pull/1843 and update eslint-plugin-react