### PR TITLE
Disable the no-unexpected-multiline rule, it clashes with prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -181,7 +181,6 @@
     "no-throw-literal": "error",
     "no-undef": "error",
     "no-undef-init": "error",
-    "no-unexpected-multiline": "error",
     "no-unmodified-loop-condition": "error",
     "no-unneeded-ternary": [
       "error",


### PR DESCRIPTION
Ran into this case in https://github.com/unexpectedjs/unexpected/pull/577:

```js
it('should inspect a fulfilled promise without a value', () => {
  expect(
    expect
      .promise(function() {
        expect(2, 'to equal', 2);
      })
      [inspectMethodName](),
    'to equal',
    'Promise (fulfilled)'
  );
});
```

The [`no-unexpected-multiline`](https://eslint.org/docs/rules/no-unexpected-multiline) rule complains about the newline before `[inspectMethodName]()`, which it wants to put right after `})` on the previous line.

[`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) also has this rule off with the following explanation: https://github.com/prettier/eslint-config-prettier#no-unexpected-multiline