### PR TITLE
bump deps dev/peer/prod - (Major)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "url": "https://github.com/sunesimonsen/eslint-config-pretty-standard.git"
   },
   "peerDependencies": {
-    "eslint": "^5",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.6.1"
+    "eslint": "^6",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.14.2"
   },
   "dependencies": {
-    "eslint-plugin-promise": "3.6.0",
-    "eslint-plugin-react": "7.10.0"
+    "eslint-plugin-promise": "4.2.1",
+    "eslint-plugin-react": "7.14.2"
   },
   "devDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "6.0.1"
   }
 }


### PR DESCRIPTION
Fixes warning when installing with latest `eslint@6`.

```
warning " > eslint-config-pretty-standard@2.0.1" has incorrect peer dependency "eslint@^5".
warning " > eslint-config-pretty-standard@2.0.1" has incorrect peer dependency "eslint-plugin-promise@^3.6.0".
warning "eslint-config-pretty-standard > eslint-plugin-react@7.10.0" has incorrect peer dependency "eslint@^3.0.0 || ^4.0.0 || ^5.0.0".
```