### PR TITLE
Defaulting to detecting the React version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -266,5 +266,10 @@
     },
     "sourceType": "module"
   },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "plugins": ["promise", "react"]
 }


### PR DESCRIPTION
The newest major complains about not being able to detecting the React version, this PR makes the React plugin auto detect the version. This will be the default for the plugin in the future.